### PR TITLE
Fixed to show the joint of the elec room door

### DIFF
--- a/LasMonjas/Helpers.cs
+++ b/LasMonjas/Helpers.cs
@@ -1222,5 +1222,16 @@ namespace LasMonjas
                 }
             }
         }
+
+        public static StaticDoor GetStaticDoor(string name)
+        {
+            foreach (var doors in Object.FindObjectsOfType(Il2CppType.Of<StaticDoor>()))
+            {
+                if (doors.name != name) continue;
+
+                return doors.CastFast<StaticDoor>();
+            }
+            return null;
+        }
     }
 }

--- a/LasMonjas/Patches/IntroPatch.cs
+++ b/LasMonjas/Patches/IntroPatch.cs
@@ -2945,30 +2945,6 @@ namespace LasMonjas.Patches
                                 airshipadmin.GetComponent<BoxCollider2D>().enabled = false;
                                 GameObject airshipvitals = GameObject.Find("panel_vitals");
                                 airshipvitals.GetComponent<CircleCollider2D>().enabled = false;
-                                GameObject LeftDoorTop = GameObject.Find("LeftDoorTop");
-                                LeftDoorTop.SetActive(false);
-                                GameObject TopLeftVert = GameObject.Find("TopLeftVert");
-                                TopLeftVert.SetActive(false);
-                                GameObject TopLeftHort = GameObject.Find("TopLeftHort");
-                                TopLeftHort.SetActive(false);
-                                GameObject BottomHort = GameObject.Find("BottomHort");
-                                BottomHort.SetActive(false);
-                                GameObject TopCenterHort = GameObject.Find("TopCenterHort");
-                                TopCenterHort.SetActive(false);
-                                GameObject LeftVert = GameObject.Find("LeftVert");
-                                LeftVert.SetActive(false);
-                                GameObject RightVert = GameObject.Find("RightVert");
-                                RightVert.SetActive(false);
-                                GameObject TopRightVert = GameObject.Find("TopRightVert");
-                                TopRightVert.SetActive(false);
-                                GameObject TopRightHort = GameObject.Find("TopRightHort");
-                                TopRightHort.SetActive(false);
-                                GameObject BottomRightHort = GameObject.Find("BottomRightHort");
-                                BottomRightHort.SetActive(false);
-                                GameObject BottomRightVert = GameObject.Find("BottomRightVert");
-                                BottomRightVert.SetActive(false);
-                                GameObject LeftDoorBottom = GameObject.Find("LeftDoorBottom");
-                                LeftDoorBottom.SetActive(false);
                                 GameObject laddermeeting = GameObject.Find("ladder_meeting");
                                 laddermeeting.SetActive(false);
                                 GameObject platform = GameObject.Find("Platform");
@@ -2979,6 +2955,20 @@ namespace LasMonjas.Patches
                                 platformright.SetActive(false);
                                 GameObject recordsadmin = GameObject.Find("records_admin_map");
                                 recordsadmin.GetComponent<BoxCollider2D>().enabled = false;
+
+                                Helpers.GetStaticDoor("TopLeftVert").SetOpen(true);
+                                Helpers.GetStaticDoor("TopLeftHort").SetOpen(true);
+                                Helpers.GetStaticDoor("BottomHort").SetOpen(true);
+                                Helpers.GetStaticDoor("TopCenterHort").SetOpen(true);
+                                Helpers.GetStaticDoor("LeftVert").SetOpen(true);
+                                Helpers.GetStaticDoor("RightVert").SetOpen(true);
+                                Helpers.GetStaticDoor("TopRightVert").SetOpen(true);
+                                Helpers.GetStaticDoor("TopRightHort").SetOpen(true);
+                                Helpers.GetStaticDoor("BottomRightHort").SetOpen(true);
+                                Helpers.GetStaticDoor("BottomRightVert").SetOpen(true);
+                                Helpers.GetStaticDoor("LeftDoorTop").SetOpen(true);
+                                Helpers.GetStaticDoor("LeftDoorBottom").SetOpen(true);
+
                                 break;
                             // Submerged
                             case 5:


### PR DESCRIPTION
Instead of deleting the GameObject, get the electrical room door from inside the game and set it to open.

For some reason, the amount of changes is amazing, but there are only the following two changes.
https://github.com/KiraYamato94/LasMonjas/compare/main...Dekokiyo:LasMonjas:main#diff-82f9003ce513b74112825dae7c10721eec87b47cf8b8e0e7aebab718045eafccR1226
https://github.com/KiraYamato94/LasMonjas/compare/main...Dekokiyo:LasMonjas:main#diff-1f7a1599fb79761e201a3576ad2ee83304e4e643c4a5fc483f252d419fa8749dL2948

![image](https://user-images.githubusercontent.com/97837904/213917811-e4fb476e-9112-40b4-b5ac-dd2379ef3c97.png)
![image](https://user-images.githubusercontent.com/97837904/213917813-3ff05687-b3e1-4535-982a-93b188c9b1b1.png)
![image](https://user-images.githubusercontent.com/97837904/213917814-112b26a2-38c6-41b2-8089-ed1a53db738b.png)
